### PR TITLE
Dockerize app

### DIFF
--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -1,0 +1,27 @@
+name: Anchore Container Scan
+on:
+  push:
+    branches:
+      - master
+      - '*security*'
+      - '*vulnerability*'
+
+jobs:
+  Anchore-Build-Scan:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag localbuild/testimage:latest
+    - name: Run the Anchore scan
+      uses: anchore/scan-action@main
+      with:
+        image: "localbuild/testimage:latest"
+        acs-report-enable: true
+        severity-cutoff: high
+    - name: Upload Anchore Scan Report
+      if: ${{ always() }}
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: results.sarif

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}
-          repository: pcic/thunderbird
+          repository: pcic/orca
           tag_with_ref: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,23 @@
+name: Docker Publishing
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish to Registry
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.pcicdevops_at_dockerhub_username }}
+          password: ${{ secrets.pcicdevops_at_dockerhub_password }}
+          repository: pcic/thunderbird
+          tag_with_ref: true

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+deployment.env
 
 # Spyder project settings
 .spyderproject

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM python:3.8-slim
 
-COPY ./requirements.txt /app/requirements.txt
+ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
+ENV LDFLAGS="-L/usr/local/opt/openssl/lib"
+ENV CPPFLAGS="-I/usr/local/opt/openssl/include"
+
+RUN apt-get update && \
+    apt-get install -y gcc libpq-dev libhdf5-serial-dev netcdf-bin libnetcdf-dev
+
+COPY . /app
 
 WORKDIR /app
 
-RUN pip upgrade -U pip && \
+RUN pip install -U pip && \
     pip install -r requirements.txt && \
     pip install -e .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.8-slim
+
+COPY ./requirements.txt /app/requirements.txt
+
+WORKDIR /app
+
+RUN pip upgrade -U pip && \
+    pip install -r requirements.txt && \
+    pip install -e .
+
+COPY . /app
+
+ENTRYPOINT ["python"]
+CMD ["orca/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM python:3.8-slim
 
 ENV PIP_INDEX_URL="https://pypi.pacificclimate.org/simple/"
-ENV LDFLAGS="-L/usr/local/opt/openssl/lib"
-ENV CPPFLAGS="-I/usr/local/opt/openssl/include"
 
 RUN apt-get update && \
-    apt-get install -y gcc libpq-dev libhdf5-serial-dev netcdf-bin libnetcdf-dev
+    apt-get install -y gcc \
+      libpq-dev \
+      libhdf5-serial-dev \
+      netcdf-bin \
+      libnetcdf-dev
 
 COPY . /app
 
@@ -17,4 +19,5 @@ RUN pip install -U pip && \
 
 COPY . /app
 
+EXPOSE 5000
 CMD ["python", "orca/app.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,4 @@ RUN pip install -U pip && \
 
 COPY . /app
 
-ENTRYPOINT ["python"]
-CMD ["orca/app.py"]
+CMD ["python", "orca/app.py"]

--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,5 @@ venv:
 .PHONY: performance
 performance: venv install
 	${PIP} install snakeviz
-	${PYTHON} -m cProfile -o program.prof scripts/process.py --url "https://data.pacificclimate.org/data/downscaled_gcms/tasmax_day_BCCAQv2+ANUSPLIN300_CanESM2_historical+rcp85_r1i1p1_19500101-21001231.nc.nc?tasmax[0:15000][0:91][0:206]&" --unique-id tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada -l DEBUG
+	${PYTHON} -m cProfile -o program.prof scripts/process.py -u tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada -t tasmax[0:15000][0:91][0:206] -l DEBUG
 	${PYTHON} -m snakeviz program.prof

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# orca (OPeNDAP Request Compiler Application)
+# OPeNDAP Request Compiler Application (`orca`)
 
 The purpose of orca is to pull apart large `OPeNDAP` requests to `THREDDS` into bite-sized chunks. These chunks are then reassembled before returning to the user.
 
@@ -17,11 +17,12 @@ export FLASK_APP=orca/app.py
 export DSN=postgresql://<USER>:<PASSWORD>@db3.pcic.uvic.ca/pcic_meta
 ```
 
-Once that has been complete `Flask` can be used to spin up an instance of `orca` on your local machine:
+Once those have all been set, `Flask` can be used to spin up an instance of `orca` on your local machine:
 ```
 flask run
 ```
-Once the instance has been spun up you can request a file from it using a URL in this form:
+
+When the instance is running you can request a url in your browser in this form:
 ```
 http://127.0.0.1:5000/orca/tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada/tasmax[0:150][0:91][0:206]
 ```
@@ -35,3 +36,10 @@ To stop the container:
 ```
 docker-compose down
 ```
+
+Again you will be able to acesss the service through a url:
+```
+http://docker-dev03.pcic.uvic.ca:30333/orca/tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada/tasmax[0:150][0:91][0:206]
+```
+
+*NOTE: The variables in `deployment.env` are private and as such must not be committed to the repo*

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ source /tmp/orca/venv/bin/activate
 ```
 
 ## Run App
+### Locally
 Before starting the app, ensure that you have set all the required environment variables:
 ```
 export FLASK_APP=orca/app.py
@@ -23,4 +24,14 @@ flask run
 Once the instance has been spun up you can request a file from it using a URL in this form:
 ```
 http://127.0.0.1:5000/orca/tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada/tasmax[0:150][0:91][0:206]
+```
+
+### Docker
+To run the `orca` docker container ensure that you have set all variables in the `deployment.env` then run:
+```
+docker-compose up -d
+```
+To stop the container:
+```
+docker-compose down
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The purpose of orca is to pull apart large `OPeNDAP` requests to `THREDDS` into 
 We use `make` to handle the installation process. Copy and paste this section into your terminal:
 ```
 make
-source /tmp/orca/venv/bin/activate
+source /tmp/orca-venv/bin/activate
 ```
 
 ## Run App

--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ We use `make` to handle the installation process. Copy and paste this section in
 make
 source /tmp/orca/venv/bin/activate
 ```
+
+## Run App
+`Flask` can be used to spin up an instance of `orca` on your local machine:
+```
+export FLASK_APP=orca/app.py
+flask run
+```
+Once the instance has been spun up you can request a file from it using a url like this:
+```
+http://127.0.0.1:5000/orca/tasmax[0:150][0:91][0:206]/tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada
+```

--- a/README.md
+++ b/README.md
@@ -10,12 +10,17 @@ source /tmp/orca/venv/bin/activate
 ```
 
 ## Run App
-`Flask` can be used to spin up an instance of `orca` on your local machine:
+Before starting the app, ensure that you have set all the required environment variables:
 ```
 export FLASK_APP=orca/app.py
+export DSN=postgresql://<USER>:<PASSWORD>@db3.pcic.uvic.ca/pcic_meta
+```
+
+Once that has been complete `Flask` can be used to spin up an instance of `orca` on your local machine:
+```
 flask run
 ```
-Once the instance has been spun up you can request a file from it using a url like this:
+Once the instance has been spun up you can request a file from it using a URL in this form:
 ```
 http://127.0.0.1:5000/orca/tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada/tasmax[0:150][0:91][0:206]
 ```

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ flask run
 ```
 Once the instance has been spun up you can request a file from it using a url like this:
 ```
-http://127.0.0.1:5000/orca/tasmax[0:150][0:91][0:206]/tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada
+http://127.0.0.1:5000/orca/tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada/tasmax[0:150][0:91][0:206]
 ```

--- a/deployment.env
+++ b/deployment.env
@@ -1,0 +1,1 @@
+DSN=postgresql://<USER>:<PASSWORD>@db3.pcic.uvic.ca/pcic_meta

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,8 @@ services:
       - "30333:5000"
     env_file:
       - deployment.env
+
+networks:
+  default:
+    external:
+      name: pcicbr0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,5 @@ services:
     container_name: orca
     ports:
       - "30333:5000"
-    restart: always
+    env_file:
+      - deployment.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.0'
+services:
+  orca:
+    image: pcic/orca:latest
+    container_name: orca
+    ports:
+      - "30333:5000"
+    restart: always

--- a/orca/app.py
+++ b/orca/app.py
@@ -19,4 +19,4 @@ def orca(unique_id, targets):
 
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0')
+    app.run(host="0.0.0.0")

--- a/orca/app.py
+++ b/orca/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, send_file
-from .main import orc
-from .utils import get_filename_from_path
+from orca.main import orc
+from orca.utils import get_filename_from_path
 
 
 app = Flask(__name__)

--- a/orca/app.py
+++ b/orca/app.py
@@ -6,14 +6,13 @@ from .utils import get_filename_from_path
 app = Flask(__name__)
 
 
-@app.route("/orca/<string:url>/<string:unique_id>", methods=["GET", "POST"])
-def orca(url, unique_id):
-    outpath = orc(url, unique_id)
-    name = get_filename_from_path(outpath)
+@app.route("/orca/<string:unique_id>/<string:targets>", methods=["GET", "POST"])
+def orca(unique_id, targets):
+    outpath = orc(unique_id, targets)
 
     return send_file(
         outpath,
         mimetype="application/x-netcdf",
         as_attachment=True,
-        attachment_filename=name,
+        attachment_filename=get_filename_from_path(outpath),
     )

--- a/orca/app.py
+++ b/orca/app.py
@@ -16,3 +16,7 @@ def orca(unique_id, targets):
         as_attachment=True,
         attachment_filename=get_filename_from_path(outpath),
     )
+
+
+if __name__ == "__main__":
+    app.run(host='0.0.0.0')

--- a/orca/app.py
+++ b/orca/app.py
@@ -1,0 +1,19 @@
+from flask import Flask, send_file
+from .main import orc
+from .utils import get_filename_from_path
+
+
+app = Flask(__name__)
+
+
+@app.route("/orca/<string:url>/<string:unique_id>", methods=["GET", "POST"])
+def orca(url, unique_id):
+    outpath = orc(url, unique_id)
+    name = get_filename_from_path(outpath)
+
+    return send_file(
+        outpath,
+        mimetype="application/x-netcdf",
+        as_attachment=True,
+        attachment_filename=name,
+    )

--- a/orca/db_handler.py
+++ b/orca/db_handler.py
@@ -1,6 +1,7 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from modelmeta import DataFile
+import os
 
 
 def find_filepath(sesh, unique_id):
@@ -13,6 +14,11 @@ def find_filepath(sesh, unique_id):
     return datafile.first().filename
 
 
-def start_session(connection_string):
-    """Create session using connection string"""
-    return sessionmaker(create_engine(connection_string))()
+def start_session():
+    """Create session using the data source name provided by the envorinment"""
+    dsn = os.environ.get("DSN")
+
+    if not dsn:
+        raise Exception("No DSN found, please set the DSN envorinment variable.")
+
+    return sessionmaker(create_engine(dsn))()

--- a/orca/main.py
+++ b/orca/main.py
@@ -6,7 +6,6 @@ from orca.utils import setup_logging
 def orc(
     unique_id,
     targets,
-    connection_string="postgresql://httpd_meta@db3.pcic.uvic.ca/pcic_meta",
     thredds_base="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
     outdir="/tmp/",
     log_level="INFO",
@@ -21,7 +20,7 @@ def orc(
     logger.info("Processing data file request")
 
     logger.debug("Starting db session")
-    sesh = start_session(connection_string)
+    sesh = start_session()
     filepath = find_filepath(sesh, unique_id)
     logger.debug(f"Got filepath: {filepath}")
 

--- a/orca/main.py
+++ b/orca/main.py
@@ -1,36 +1,38 @@
 from .db_handler import find_filepath, start_session
-from .requester import build_url, file_from_opendap, decompose_url
+from .requester import build_opendap_url, file_from_opendap, decompose_target
 from .utils import setup_logging
 
 
 def orc(
-    url,
+    target,
     unique_id,
     connection_string="postgresql://httpd_meta@db3.pcic.uvic.ca/pcic_meta",
     thredds_base="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
-    outfile="outfile.nc",
+    outdir="/tmp/",
     log_level="INFO",
 ):
     """OPeNDAP Request Complier
 
     Builds an OPeNDAP request that can be split into a series of requests and
-    compiled back into a single output.
+    compiled back into a single output. This output is written to the `outpath`
+    location and that same location is returned from this method.
     """
     logger = setup_logging(log_level)
     logger.info("Processing data file request")
 
-    variable, lat, lon = decompose_url(url)
+    variable, lat, lon = decompose_target(target)
 
     logger.debug("Starting db session")
     sesh = start_session(connection_string)
     filepath = find_filepath(sesh, unique_id)
     logger.debug(f"Got filepath: {filepath}")
 
-    url = build_url(thredds_base, filepath, variable, lat, lon)
-    logger.debug(f"Initial url: {url}")
+    opendap_url = build_opendap_url(thredds_base, filepath, variable, lat, lon)
+    logger.debug(f"Initial OPeNDAP URL: {opendap_url}")
 
-    logger.info("Downloading data file(s)")
-    file_from_opendap(url, outfile)
+    logger.info("Downloading data from OPeNDAP")
+    outpath = file_from_opendap(opendap_url, outdir)
+    logger.debug(f"Result avaialble at {outpath}")
 
     logger.info("Complete")
-    return outfile
+    return outpath

--- a/orca/main.py
+++ b/orca/main.py
@@ -25,7 +25,7 @@ def orc(
     filepath = find_filepath(sesh, unique_id)
     logger.debug(f"Got filepath: {filepath}")
 
-    opendap_url = build_opendap_url(thredds_base, filepath, variable, lat, lon)
+    opendap_url = build_opendap_url(thredds_base, filepath, targets)
     logger.debug(f"Initial OPeNDAP URL: {opendap_url}")
 
     logger.info("Downloading data from OPeNDAP")

--- a/orca/main.py
+++ b/orca/main.py
@@ -8,6 +8,7 @@ def orc(
     targets,
     thredds_base="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
     outdir="/tmp/",
+    outfile="",
     log_level="INFO",
 ):
     """OPeNDAP Request Complier
@@ -28,7 +29,7 @@ def orc(
     logger.debug(f"Initial OPeNDAP URL: {opendap_url}")
 
     logger.info("Downloading data from OPeNDAP")
-    outpath = file_from_opendap(opendap_url, outdir)
+    outpath = file_from_opendap(opendap_url, outdir, outfile)
     logger.debug(f"Result avaialble at {outpath}")
 
     logger.info("Complete")

--- a/orca/main.py
+++ b/orca/main.py
@@ -1,6 +1,6 @@
-from .db_handler import find_filepath, start_session
-from .requester import build_opendap_url, file_from_opendap
-from .utils import setup_logging
+from orca.db_handler import find_filepath, start_session
+from orca.requester import build_opendap_url, file_from_opendap
+from orca.utils import setup_logging
 
 
 def orc(

--- a/orca/main.py
+++ b/orca/main.py
@@ -1,11 +1,11 @@
 from .db_handler import find_filepath, start_session
-from .requester import build_opendap_url, file_from_opendap, decompose_target
+from .requester import build_opendap_url, file_from_opendap
 from .utils import setup_logging
 
 
 def orc(
-    target,
     unique_id,
+    targets,
     connection_string="postgresql://httpd_meta@db3.pcic.uvic.ca/pcic_meta",
     thredds_base="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
     outdir="/tmp/",
@@ -19,8 +19,6 @@ def orc(
     """
     logger = setup_logging(log_level)
     logger.info("Processing data file request")
-
-    variable, lat, lon = decompose_target(target)
 
     logger.debug("Starting db session")
     sesh = start_session(connection_string)

--- a/orca/requester.py
+++ b/orca/requester.py
@@ -9,22 +9,24 @@ from datetime import datetime
 logger = logging.getLogger("scripts")
 
 
-def file_from_opendap(url, outdir):
+def file_from_opendap(url, outdir, outfile):
     """Write to file from OPeNDAP link"""
     checkset = open_dataset(url)
     urls = split_url(url, checkset.nbytes)
 
     logger.debug(f"Downloading from {len(urls)} URL(s): {urls}")
     dataset = open_mfdataset(urls, combine="nested", concat_dim="time")
-    outfile = to_file(dataset, outdir)
+    outpath = to_file(dataset, outdir, outfile)
 
-    return outfile
+    return outpath
 
 
-def to_file(dataset, outdir):
+def to_file(dataset, outdir, outfile=""):
     """Write netcdf to generated filename"""
-    now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    outfile = f"orca-output-{now}"
+    if not outfile:
+        now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        outfile = f"orca-output-{now}"
+
     outpath = outdir + outfile
 
     logger.debug("Begin file write")

--- a/orca/requester.py
+++ b/orca/requester.py
@@ -2,23 +2,39 @@ import logging
 from xarray import open_mfdataset, open_dataset
 import re
 from math import ceil
+import os
+from datetime import datetime
 
 
 logger = logging.getLogger("scripts")
 
 
-def file_from_opendap(url, outfile):
+def file_from_opendap(url, outdir):
     """Write to file from OPeNDAP link"""
-    data = open_dataset(url)
-    urls = split_url(url, data.nbytes)
-    logger.debug(f"URL(s) for downloading: {urls})")
+    checkset = open_dataset(url)
+    urls = split_url(url, checkset.nbytes)
 
-    logger.debug(f"Downloading and merging {len(urls)} split files")
-    open_mfdataset(urls, combine="nested", concat_dim="time").to_netcdf(outfile)
-    logger.debug("File writing complete")
+    logger.debug(f"Downloading from {len(urls)} URL(s): {urls}")
+    dataset = open_mfdataset(urls, combine="nested", concat_dim="time")
+    outfile = to_file(dataset, outdir)
+
+    return outfile
 
 
-def build_url(thredds_base, filepath, variable, lat, lon):
+def to_file(dataset, outdir):
+    """Write netcdf to generated filename"""
+    now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    outfile = f"orca-output-{now}"
+    outpath = outdir + outfile
+
+    logger.debug("Begin file write")
+    dataset.to_netcdf(outpath)
+    logger.debug("File write complete")
+
+    return outpath
+
+
+def build_opendap_url(thredds_base, filepath, variable, lat, lon):
     """Construct url for OPeNDAP"""
     return f"{thredds_base}{filepath}?{variable}{lat}{lon}"
 
@@ -35,7 +51,7 @@ def split_url(url, size, threshold=5e8):
     bytes = size / 2
 
     if bytes > threshold:
-        logger.debug(f"Splitting, request over threshold: {bytes}")
+        logger.debug(f"Splitting, request over threshold: {bytes * 10**-6}/500mb")
         start_end_format = re.compile(r"(([a-z]+)\[(\d*)(:\d*){0,1}:(\d*)\])")
         var_time, var, start, stride, end = start_end_format.findall(url)[0]
         start = int(start)
@@ -60,13 +76,12 @@ def split_url(url, size, threshold=5e8):
         return urls
 
     else:
-        logger.debug(f"Request under threshold: {bytes}")
+        logger.debug(f"Request under threshold: {bytes * 10**-6}/500mb")
         return [url]
 
 
-def decompose_url(url):
-    """Takes the url from the data portal and breaks it down into usable pieces"""
-    _, pieces = url.split("?")
+def decompose_target(target):
+    """Takes the variable target string given by data portal and breaks it into pieces"""
     pattern = "([a-z]+\[\d+:\d+\])(\[\d+:\d+\])(\[\d+:\d+\])"
-    (match,) = re.findall(pattern, pieces)
+    (match,) = re.findall(pattern, target)
     return match

--- a/orca/requester.py
+++ b/orca/requester.py
@@ -34,9 +34,9 @@ def to_file(dataset, outdir):
     return outpath
 
 
-def build_opendap_url(thredds_base, filepath, variable, lat, lon):
+def build_opendap_url(thredds_base, filepath, targets):
     """Construct url for OPeNDAP"""
-    return f"{thredds_base}{filepath}?{variable}{lat}{lon}"
+    return f"{thredds_base}{filepath}?{targets}"
 
 
 def split_url(url, size, threshold=5e8):
@@ -78,10 +78,3 @@ def split_url(url, size, threshold=5e8):
     else:
         logger.debug(f"Request under threshold: {bytes * 10**-6}/500mb")
         return [url]
-
-
-def decompose_target(target):
-    """Takes the variable target string given by data portal and breaks it into pieces"""
-    pattern = "([a-z]+\[\d+:\d+\])(\[\d+:\d+\])(\[\d+:\d+\])"
-    (match,) = re.findall(pattern, target)
-    return match

--- a/orca/utils.py
+++ b/orca/utils.py
@@ -11,3 +11,8 @@ def setup_logging(log_level):
     logger.addHandler(handler)
     logger.setLevel(getattr(logging, log_level))
     return logger
+
+
+def get_filename_from_path(path):
+    """Given a path, return the filename on the end"""
+    return path.split("/")[-1]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click==7.1.2
 dask[complete]==2021.2.0
+Flask==1.1.2
 modelmeta==0.2.0
 psycopg2==2.8.6
 scipy==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 click==7.1.2
-dask[complete]==2021.2.0
+dask[dataframe]
 Flask==1.1.2
 modelmeta==0.2.0
 psycopg2==2.8.6
-scipy==1.6.1
 SQLAlchemy==1.3.23
 xarray==0.16.2

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -18,6 +18,7 @@ from orca.main import orc
 @click.option(
     "-o", "--outdir", help="Desired dir to store generated output", default="/tmp/"
 )
+@click.option("-f", "--outfile", help="Custom output filename", default="")
 @click.option(
     "-l",
     "--log-level",
@@ -27,9 +28,9 @@ from orca.main import orc
         ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], case_sensitive=False
     ),
 )
-def process(unique_id, targets, connection_string, thredds_base, outdir, log_level):
+def process(unique_id, targets, thredds_base, outdir, outfile, log_level):
     """CLI for orca"""
-    orc(unique_id, targets, thredds_base, outdir, log_level)
+    orc(unique_id, targets, thredds_base, outdir, outfile, log_level)
 
 
 if __name__ == "__main__":

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -3,8 +3,8 @@ from orca.main import orc
 
 
 @click.command()
-@click.option("--url", help="Data portal URL")
-@click.option("--unique-id", help="Unique_id to search for in DB")
+@click.option("-u", "--unique-id", help="Unique_id to search for in DB")
+@click.option("-t", "--targets", help="These are the data file targets in the form `variable[time_start:time_end][lat_start:lat_end][lon_start:lon_end]` (ex. tasmax[0:100][91:91][206:206])")
 @click.option(
     "-x",
     "--connection-string",
@@ -17,11 +17,11 @@ from orca.main import orc
     help="Base path for all OPeNDAP links",
     default="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
 )
-@click.option("-o", "--outfile", help="Output file path", default="outfile.nc")
-@click.option("-l", "--log-level", help="Ouput file path", default="INFO")
-def process(url, unique_id, connection_string, thredds_base, outfile, log_level):
+@click.option("-o", "--outdir", help="Desired dir to store generated output", default="/tmp/")
+@click.option("-l", "--log-level", help="Logging level", default="INFO", type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], case_sensitive=False))
+def process(unique_id, targets, connection_string, thredds_base, outdir, log_level):
     """CLI for orca"""
-    orc(url, unique_id, connection_string, thredds_base, outfile, log_level)
+    orc(unique_id, targets, connection_string, thredds_base, outdir, log_level)
 
 
 if __name__ == "__main__":

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -6,12 +6,6 @@ from orca.main import orc
 @click.option("-u", "--unique-id", help="Unique_id to search for in DB")
 @click.option("-t", "--targets", help="These are the data file targets in the form `variable[time_start:time_end][lat_start:lat_end][lon_start:lon_end]` (ex. tasmax[0:100][91:91][206:206])")
 @click.option(
-    "-x",
-    "--connection-string",
-    help="Database connection string",
-    default="postgresql://httpd_meta@db3.pcic.uvic.ca/pcic_meta",
-)
-@click.option(
     "-b",
     "--thredds-base",
     help="Base path for all OPeNDAP links",
@@ -21,7 +15,7 @@ from orca.main import orc
 @click.option("-l", "--log-level", help="Logging level", default="INFO", type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], case_sensitive=False))
 def process(unique_id, targets, connection_string, thredds_base, outdir, log_level):
     """CLI for orca"""
-    orc(unique_id, targets, connection_string, thredds_base, outdir, log_level)
+    orc(unique_id, targets, thredds_base, outdir, log_level)
 
 
 if __name__ == "__main__":

--- a/scripts/process.py
+++ b/scripts/process.py
@@ -4,15 +4,29 @@ from orca.main import orc
 
 @click.command()
 @click.option("-u", "--unique-id", help="Unique_id to search for in DB")
-@click.option("-t", "--targets", help="These are the data file targets in the form `variable[time_start:time_end][lat_start:lat_end][lon_start:lon_end]` (ex. tasmax[0:100][91:91][206:206])")
+@click.option(
+    "-t",
+    "--targets",
+    help="These are the data file targets in the form `variable[time_start:time_end][lat_start:lat_end][lon_start:lon_end]` (ex. tasmax[0:100][91:91][206:206])",
+)
 @click.option(
     "-b",
     "--thredds-base",
     help="Base path for all OPeNDAP links",
     default="https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
 )
-@click.option("-o", "--outdir", help="Desired dir to store generated output", default="/tmp/")
-@click.option("-l", "--log-level", help="Logging level", default="INFO", type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], case_sensitive=False))
+@click.option(
+    "-o", "--outdir", help="Desired dir to store generated output", default="/tmp/"
+)
+@click.option(
+    "-l",
+    "--log-level",
+    help="Logging level",
+    default="INFO",
+    type=click.Choice(
+        ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], case_sensitive=False
+    ),
+)
 def process(unique_id, targets, connection_string, thredds_base, outdir, log_level):
     """CLI for orca"""
     orc(unique_id, targets, thredds_base, outdir, log_level)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,29 +7,29 @@ from orca import main, requester, db_handler
 
 @pytest.mark.online
 @pytest.mark.parametrize(
-    ("url", "expected"),
-    [
-        (
-            "https://data.pacificclimate.org/data/downscaled_gcms/tasmax_day_BCCAQv2+ANUSPLIN300_CanESM2_historical+rcp85_r1i1p1_19500101-21001231.nc.nc?tasmax[0:0][0:91][0:206]&",
-            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/climate/downscale/BCCAQ2/bccaqv2_with_metadata/tasmax_day_BCCAQv2+ANUSPLIN300_CanESM2_historical+rcp85_r1i1p1_19500101-21001231.nc?tasmax[0:1:0][0:1:91][0:1:206]",
-        ),
-        (
-            "https://data.pacificclimate.org/data/downscaled_gcms/tasmax_day_BCCAQv2+ANUSPLIN300_CanESM2_historical+rcp85_r1i1p1_19500101-21001231.nc.nc?tasmax[0:15000][0:91][0:206]&",
-            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/climate/downscale/BCCAQ2/bccaqv2_with_metadata/tasmax_day_BCCAQv2+ANUSPLIN300_CanESM2_historical+rcp85_r1i1p1_19500101-21001231.nc?tasmax[0:1:15000][0:1:91][0:1:206]",
-        ),
-    ],
-)
-@pytest.mark.parametrize(
     ("unique_id"),
     [
         "tasmax_day_BCCAQv2_CanESM2_historical-rcp85_r1i1p1_19500101-21001231_Canada",
     ],
 )
-def test_main(url, unique_id, expected):
+@pytest.mark.parametrize(
+    ("targets", "expected"),
+    [
+        (
+            "tasmax[0:0][0:91][0:206]",
+            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/climate/downscale/BCCAQ2/bccaqv2_with_metadata/tasmax_day_BCCAQv2+ANUSPLIN300_CanESM2_historical+rcp85_r1i1p1_19500101-21001231.nc?tasmax[0:1:0][0:1:91][0:1:206]",
+        ),
+        (
+            "tasmax[0:15000][0:91][0:206]",
+            "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets/storage/data/climate/downscale/BCCAQ2/bccaqv2_with_metadata/tasmax_day_BCCAQv2+ANUSPLIN300_CanESM2_historical+rcp85_r1i1p1_19500101-21001231.nc?tasmax[0:1:15000][0:1:91][0:1:206]",
+        ),
+    ],
+)
+def test_main(unique_id, targets, expected):
     with NamedTemporaryFile(suffix=".nc", dir="/tmp") as outfile:
-        output = main.orc(url, unique_id, outfile=outfile.name)
+        outpath = main.orc(unique_id, targets, outdir="", outfile=outfile.name)
 
-        with open_dataset(output) as result, open_dataset(expected) as expected:
+        with open_dataset(outpath) as result, open_dataset(expected) as expected:
             assert result.dims == expected.dims
 
         outfile.close()

--- a/tests/test_requester.py
+++ b/tests/test_requester.py
@@ -4,7 +4,7 @@ from math import ceil
 from tempfile import NamedTemporaryFile
 from xarray import open_dataset
 
-from orca.requester import file_from_opendap, build_url, split_url
+from orca.requester import file_from_opendap, build_opendap_url, split_url
 
 
 @pytest.mark.online
@@ -21,33 +21,31 @@ from orca.requester import file_from_opendap, build_url, split_url
 )
 def test_file_from_opendap(url):
     with NamedTemporaryFile(suffix=".nc", dir="/tmp") as temp:
-        file_from_opendap(url, temp.name)
+        file_from_opendap(url, outdir="", outfile=temp.name)
         with open_dataset(url) as expected, open_dataset(temp.name) as data:
             assert expected.dims == data.dims
 
 
 @pytest.mark.parametrize(
-    ("thredds_base", "filepath", "lat", "lon"),
+    ("thredds_base", "filepath"),
     [
         (
             "https://docker-dev03.pcic.uvic.ca/twitcher/ows/proxy/thredds/dodsC/datasets",
             "/storage/data/climate/downscale/BCCAQ2/bccaqv2_with_metadata/tasmax_day_BCCAQv2+ANUSPLIN300_CSIRO-Mk3-6-0_historical+rcp85_r1i1p1_19500101-21001231.nc",
-            "[91:91]",
-            "[206:1:206]",
         ),
     ],
 )
 @pytest.mark.parametrize(
-    ("variable"),
+    ("targets"),
     [
-        "tasmax[0:1:55114]",
-        "tasmax[0:55114]",
+        "tasmax[0:1:55114][91:91][206:1:206]",
+        "tasmax[0:55114][91:91][206:1:206]",
     ],
 )
-def test_build_url(thredds_base, filepath, variable, lat, lon):
-    url = build_url(thredds_base, filepath, variable, lat, lon)
-    assert url.startswith(f"{thredds_base}{filepath}")
-    assert url.endswith(f"{variable}{lat}{lon}")
+def test_build_opendap_url(thredds_base, filepath, targets):
+    url = build_opendap_url(thredds_base, filepath, targets)
+    for expected in [thredds_base, filepath, targets]:
+        assert expected in url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR "dockerizes" `orca` such that we can hit it with urls. Before, the package was accepting the full data portal url as an input. Now that we are communicating with it through urls we probably don't want to send another url as a parameter. As such there have been a number of changes to accommodate this.

Resolves #19. 